### PR TITLE
Fix typo and when exceptions with past reviewDate are handeld as compliant on the report page

### DIFF
--- a/report.php
+++ b/report.php
@@ -109,7 +109,6 @@ if (isset($_POST['logout'])) {
                     if ($_SESSION['user_role'] == 1) {
                         echo '
                     <th scope="col">Create an Exception</th>
-                    }
                     </tr>
                 </thead>
                 <tbody>';

--- a/report.php
+++ b/report.php
@@ -96,7 +96,7 @@ if (isset($_POST['logout'])) {
             $stmt->bindValue(':cID', $_SESSION['cID']);
             $stmt->execute();
             $test = $stmt->fetch();
-            if (empty($test)) {
+            if (empty($test) || strtotime("today") >= strtotime($test[1])) {
 
                 if ($countNonCompliant == 0) {
                     echo '
@@ -206,7 +206,7 @@ if (isset($_POST['logout'])) {
         echo '</tbody></table>';
         if ($countCompliant == 0) {
 
-            echo '<p style="text-align:center">There is no resourses which do comply with this rule</p>';
+            echo '<p style="text-align:center">There is no resources which do comply with this rule</p>';
         }
 
         ?>


### PR DESCRIPTION
Make this disappear:
![image](https://user-images.githubusercontent.com/30931656/195923085-3c27ca2e-dbf1-49c8-8ebe-359226e25e3e.png)
